### PR TITLE
Add support for entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ marketing/samples/twitter4rails.post-0_2_4/log
 marketing/samples/twitter4rails.post-0_2_4/tmp
 twitter*.gem
 coverage.data
+coverage
+gemfile.lock
+*.gemspec
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ twitter*.gem
 coverage.data
 coverage
 gemfile.lock
-*.gemspec
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ marketing/samples/twitter4rails.post-0_2_4/log
 marketing/samples/twitter4rails.post-0_2_4/tmp
 twitter*.gem
 coverage.data
+coverage
+gemfile.lock
+*.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :gemcutter
 
-gem "oauth", ">=0.4.1"
+gem "oauth", ">=0.4.5"
 gem "rake"
 
 if RUBY_VERSION < "1.9.0"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Code:
 * Filipe Giusti <filipegiusti at gmail dot com> - fixed users/show issue that Twitter.com changed from under us, also inspired the v0.5.2 bugfix release by submitting great issue example code.
 * Seth Cousins <seth.cousins at gmail dot com> - added HTTP timeout option and provided a patch that inspired the OAuth support for Twitter4R
 * John McKerrell <@mcknut on twitter> - added geo attribute to Twitter::Message.
+* domrout on GitHub - added Tweet Entities.
 
 Design Suggestions:
 

--- a/bin/t4rsh
+++ b/bin/t4rsh
@@ -2,19 +2,19 @@
 
 require("irb")
 require("irb/completion")
-require("rubygems")
 
 begin
-  gem('twitter4r', '>0.3.0')
+  gem('twitter4r', '>=0.5.0')
   require("twitter")
   require("twitter/console")
 rescue Gem::LoadError
   begin
-    gem("mbbx6spp-twitter4r", '>=0.3.1')
+    require("rubygems")
+    gem("twitter4r", '>=0.5.0')
     require("twitter")
     require("twitter/console")
   rescue Gem::LoadError
-    abort("Error: You must install either twitter4r gem from Rubyforge with version 0.3.1 or greater or the mbbx6spp-twitter4r gem from GitHub's servers with version 0.3.1 or greater (and make sure it is a recent version of the gem).")
+    abort("Error: You must install a twitter4r gem of version 0.5.0 or greater.")
   end
 end
 

--- a/lib/twitter/config.rb
+++ b/lib/twitter/config.rb
@@ -72,10 +72,10 @@ module Twitter
   end
 
   class Client
-    @@defaults = { :host => 'twitter.com', 
+    @@defaults = { :host => 'api.twitter.com', 
                    :port => 443, 
                    :protocol => :ssl,
-                   :path_prefix => "",
+                   :path_prefix => "/1",
                    :search_host => 'search.twitter.com',
                    :search_port => 80,
                    :search_protocol => :http,

--- a/lib/twitter/config.rb
+++ b/lib/twitter/config.rb
@@ -17,6 +17,10 @@ module Twitter
   # * <tt>proxy_port</tt> - proxy host to use.  Defaults to 8080.
   # * <tt>proxy_user</tt> - proxy username to use.  Defaults to nil.
   # * <tt>proxy_pass</tt> - proxy password to use.  Defaults to nil.
+  # * <tt>media_protocol</tt> - <tt>:http</tt>, <tt>:https</tt> or <tt>:ssl</tt> supported.  <tt>:ssl</tt> is an alias for <tt>:https</tt>.  Defaults to <tt>:ssl</tt>
+  # * <tt>media_host</tt> - hostname to connect to for the Twitter Upload service.  Defaults to <tt>'twitter.com'</tt>.
+  # * <tt>media_port</tt> - port to connect to for the Twitter Upload service.  Defaults to <tt>443</tt>.
+  # * <tt>media_path_prefix</tt> - path to prefix URIs of Upload API calls.  Defaults to <tt>""</tt>.
   # * <tt>user_agent</tt> - user agent string to use for each request of the HTTP header.
   # * <tt>application_name</tt> - name of your client application.  Defaults to 'Twitter4R'.
   # * <tt>application_version</tt> - version of your client application.  Defaults to current <tt>Twitter::Version.to_version</tt>.
@@ -40,10 +44,14 @@ module Twitter
       :search_port,
       :search_path_prefix,
       :proxy_protocol,
-      :proxy_host, 
-      :proxy_port, 
-      :proxy_user, 
-      :proxy_pass, 
+      :proxy_host,
+      :proxy_port,
+      :proxy_user,
+      :proxy_pass,
+      :media_protocol,
+      :media_host,
+      :media_port,
+      :media_path_prefix,
       :user_agent,
       :application_name,
       :application_version,
@@ -83,6 +91,10 @@ module Twitter
                    :proxy_protocol => "http",
                    :proxy_host => nil,
                    :proxy_port => 8080,
+                   :media_host => 'upload.twitter.com',
+                   :media_port => 443,
+                   :media_protocol => :ssl,
+                   :media_path_prefix => "",
                    :user_agent => "default",
                    :application_name => 'Twitter4R',
                    :application_version => Twitter::Version.to_version,

--- a/lib/twitter/config.rb
+++ b/lib/twitter/config.rb
@@ -1,15 +1,15 @@
-# config.rb contains classes, methods and extends existing Twitter4R classes 
+# config.rb contains classes, methods and extends existing Twitter4R classes
 # to provide easy configuration facilities.
 
 module Twitter
   # Represents global configuration for Twitter::Client.
   # Can override the following configuration options:
   # * <tt>protocol</tt> - <tt>:http</tt>, <tt>:https</tt> or <tt>:ssl</tt> supported.  <tt>:ssl</tt> is an alias for <tt>:https</tt>.  Defaults to <tt>:ssl</tt>
-  # * <tt>host</tt> - hostname to connect to for the Twitter service.  Defaults to <tt>'twitter.com'</tt>.
+  # * <tt>host</tt> - hostname to connect to for the Twitter service.  Defaults to <tt>'api.twitter.com'</tt>.
   # * <tt>port</tt> - port to connect to for the Twitter service.  Defaults to <tt>443</tt>.
-  # * <tt>path_prefix</tt> - path to prefix URIs of REST API calls.  Defaults to <tt>""</tt>.
+  # * <tt>path_prefix</tt> - path to prefix URIs of REST API calls.  Defaults to <tt>"1"</tt>.
   # * <tt>search_protocol</tt> - <tt>:http</tt>, <tt>:https</tt> or <tt>:ssl</tt> supported.  <tt>:ssl</tt> is an alias for <tt>:https</tt>.  Defaults to <tt>:ssl</tt>
-  # * <tt>search_host</tt> - hostname to connect to for the Twitter Search service.  Defaults to <tt>'twitter.com'</tt>.
+  # * <tt>search_host</tt> - hostname to connect to for the Twitter Search service.  Defaults to <tt>'search.twitter.com'</tt>.
   # * <tt>search_port</tt> - port to connect to for the Twitter Search service.  Defaults to <tt>443</tt>.
   # * <tt>search_path_prefix</tt> - path to prefix URIs of Search API calls.  Defaults to <tt>""</tt>.
   # * <tt>proxy_protocol</tt> - proxy protocol to use.  Defaults to http.
@@ -35,9 +35,9 @@ module Twitter
   class Config
     include ClassUtilMixin
     @@ATTRIBUTES = [
-      :protocol, 
-      :host, 
-      :port, 
+      :protocol,
+      :host,
+      :port,
       :path_prefix,
       :search_protocol,
       :search_host,
@@ -67,8 +67,8 @@ module Twitter
     ]
 
     attr_accessor(*@@ATTRIBUTES)
-    
-    # Override of Object#eql? to ensure RSpec specifications run 
+
+    # Override of Object#eql? to ensure RSpec specifications run
     # correctly. Also done to follow Ruby best practices.
     def eql?(other)
       return true if self == other
@@ -80,13 +80,13 @@ module Twitter
   end
 
   class Client
-    @@defaults = { :host => 'twitter.com', 
-                   :port => 443, 
+    @@defaults = { :host => 'api.twitter.com',
+                   :port => 443,
                    :protocol => :ssl,
-                   :path_prefix => "",
+                   :path_prefix => "1",
                    :search_host => 'search.twitter.com',
-                   :search_port => 80,
-                   :search_protocol => :http,
+                   :search_port => 443,
+                   :search_protocol => :ssl,
                    :search_path_prefix => "",
                    :proxy_protocol => "http",
                    :proxy_host => nil,
@@ -94,7 +94,7 @@ module Twitter
                    :media_host => 'upload.twitter.com',
                    :media_port => 443,
                    :media_protocol => :ssl,
-                   :media_path_prefix => "",
+                   :media_path_prefix => "1",
                    :user_agent => "default",
                    :application_name => 'Twitter4R',
                    :application_version => Twitter::Version.to_version,
@@ -120,6 +120,6 @@ module Twitter
         raise ArgumentError, "Block must be provided to configure" unless block_given?
         yield config
       end # configure
-    end # class << self    
+    end # class << self
   end # Client class
 end # Twitter module

--- a/lib/twitter/model.rb
+++ b/lib/twitter/model.rb
@@ -31,6 +31,7 @@ module Twitter
       # since this is all <tt>Twitter4R</tt> needs.
       def unmarshal(raw)
         input = JSON.parse(raw) if raw.is_a?(String)
+
         def unmarshal_model(hash)
           self.new(hash)
         end
@@ -334,12 +335,24 @@ module Twitter
     end
   end # User
   
+
+  class Url
+      include ModelMixin
+      @@ATTRIBUTES = [:url, :display_url, :expanded_url, :indices ]
+      attr_accessor(*@@ATTRIBUTES)
+
+      class << self
+        # Used as factory method callback
+        def attributes; @@ATTRIBUTES; end
+      end
+  end # Url
+
   # Represents a status posted to <tt>Twitter</tt> by a <tt>Twitter</tt> user.
   class Status
     include ModelMixin
     @@ATTRIBUTES = [:id, :id_str, :text, :source, :truncated, :created_at, :user, 
                     :from_user, :to_user, :favorited, :in_reply_to_status_id, 
-                    :in_reply_to_user_id, :in_reply_to_screen_name, :geo]
+                    :in_reply_to_user_id, :in_reply_to_screen_name, :geo, :entities, :urls]
     attr_accessor(*@@ATTRIBUTES)
 
     class << self
@@ -398,6 +411,9 @@ module Twitter
       # Constructor callback
       def init
         @user = User.new(@user) if @user.is_a?(Hash)
+        puts @entities
+        @urls = @entities["urls"].collect {|e| Url.new(e)} if @entities.is_a?(Hash)
+
         @created_at = Time.parse(@created_at) if @created_at.is_a?(String)
       end    
   end # Status

--- a/lib/twitter/model.rb
+++ b/lib/twitter/model.rb
@@ -334,8 +334,38 @@ module Twitter
       @client.user(@id, :friends)
     end
   end # User
-  
 
+  # Represents the entities from a <tt>Twitter</tt> post
+  #
+  # Can include media, user mentions, URLs and hashtags. For more details see:
+  # https://dev.twitter.com/docs/tweet-entities
+  #
+  # Must enable include_entities as an option in the request to receive these.
+  class Entities 
+    include ModelMixin
+    @@ATTRIBUTES = [:urls, :media, :user_mentions, :hashtags ]
+    attr_accessor(*@@ATTRIBUTES)
+
+    class << self
+      # Used as factory method callback
+      def attributes; @@ATTRIBUTES; end
+    end
+
+    protected
+      # Constructor callback
+      def init
+        @urls = @urls.collect {|e| e.is_a?(Hash) ? Url.new(e) : e } if @urls.is_a?(Array)
+        @media = @media.collect {|e| e.is_a?(Hash) ? Media.new(e) : e } if @media.is_a?(Array)
+        @user_mentions = @user_mentions.collect {|e| e.is_a?(Hash) ? UserMention.new(e) : e } if @user_mentions.is_a?(Array)
+        @hashtags = @hashtags.collect {|e| e.is_a?(Hash) ? HashTag.new(e) : e } if @hashtags.is_a?(Array)
+
+      end    
+  end 
+
+  # Represents a URL entity.
+  #
+  # For details, see:
+  # https://dev.twitter.com/docs/tweet-entities
   class Url
       include ModelMixin
       @@ATTRIBUTES = [:url, :display_url, :expanded_url, :indices ]
@@ -345,14 +375,69 @@ module Twitter
         # Used as factory method callback
         def attributes; @@ATTRIBUTES; end
       end
+
+      def to_s
+        @display_url
+      end
   end # Url
+
+  # Represents a media entity.
+  #
+  # For details, see:
+  # https://dev.twitter.com/docs/tweet-entities
+  class Media
+      include ModelMixin
+      @@ATTRIBUTES = [:id, :id_str, :media_url, :media_url_https, :url, :display_url,
+                      :expanded_url, :sizes, :type, :indices ]
+      attr_accessor(*@@ATTRIBUTES)
+
+      class << self
+        # Used as factory method callback
+        def attributes; @@ATTRIBUTES; end
+      end
+  end # Media
+
+  # Represents a user mention entity.
+  #
+  # For details, see:
+  # https://dev.twitter.com/docs/tweet-entities
+  class UserMention
+      include ModelMixin
+      @@ATTRIBUTES = [:id, :id_str, :screen_name, :name, :indices ]
+      attr_accessor(*@@ATTRIBUTES)
+
+      class << self
+        # Used as factory method callback
+        def attributes; @@ATTRIBUTES; end
+      end
+
+      def to_s  
+        "@#{@screen_name}"
+      end
+  end # UserMention
+
+
+  # Represents a hashtag entity.
+  #
+  # For details, see:
+  # https://dev.twitter.com/docs/tweet-entities
+  class HashTag
+      include ModelMixin
+      @@ATTRIBUTES = [:text, :indices ]
+      attr_accessor(*@@ATTRIBUTES)
+
+      class << self
+        # Used as factory method callback
+        def attributes; @@ATTRIBUTES; end
+      end
+  end # Hashtag
 
   # Represents a status posted to <tt>Twitter</tt> by a <tt>Twitter</tt> user.
   class Status
     include ModelMixin
     @@ATTRIBUTES = [:id, :id_str, :text, :source, :truncated, :created_at, :user, 
                     :from_user, :to_user, :favorited, :in_reply_to_status_id, 
-                    :in_reply_to_user_id, :in_reply_to_screen_name, :geo, :entities, :urls]
+                    :in_reply_to_user_id, :in_reply_to_screen_name, :geo, :entities]
     attr_accessor(*@@ATTRIBUTES)
 
     class << self
@@ -411,8 +496,7 @@ module Twitter
       # Constructor callback
       def init
         @user = User.new(@user) if @user.is_a?(Hash)
-        puts @entities
-        @urls = @entities["urls"].collect {|e| Url.new(e)} if @entities.is_a?(Hash)
+        @entities = Entities.new(@entities) if @entities.is_a?(Hash)
 
         @created_at = Time.parse(@created_at) if @created_at.is_a?(String)
       end    

--- a/lib/twitter/version.rb
+++ b/lib/twitter/version.rb
@@ -3,14 +3,14 @@
 
 module Twitter::Version #:nodoc:
   MAJOR = 0
-  MINOR = 7
-  REVISION = 1
+  MINOR = 8
+  REVISION = 0
   class << self
     # Returns X.Y.Z formatted version string
     def to_version
       "#{MAJOR}.#{MINOR}.#{REVISION}"
     end
-    
+
     # Returns X-Y-Z formatted version name
     def to_name
       "#{MAJOR}_#{MINOR}_#{REVISION}"

--- a/pkg-info.yml
+++ b/pkg-info.yml
@@ -6,7 +6,7 @@ spec:
   require_path: lib
   has_rdoc: true
   extra_rdoc_files:
-  - README
+  - "README.md"
   - CHANGES
   - TODO
   - MIT-LICENSE
@@ -14,18 +14,19 @@ spec:
   bindir: bin
   executables: 
   - t4rsh
-  - t4r-oauth-access
+  - "t4r-oauth-access"
+
   add_dependency:
-    json: >=1.1.1
-    oauth: >=0.4.1
+    json: ">= 1.1.1"
+    oauth: ">= 0.4.1"
   requirements:
   - Ruby 1.8.6+
   - json gem, version 0.4.3 or higher
   - jcode (for unicode support)
-  required_ruby_version: >=1.8.6
+  required_ruby_version: ">=1.8.6"
   author: Susan Potter
   email: twitter4r-users@googlegroups.com
-  homepage: http://twitter4r.rubyforge.org
+  homepage: "http://twitter4r.rubyforge.org"
   rubyforge_project: twitter4r
   files: <% (self.project_files + self.spec_files).each do |file| %>
   - <%= Pathname.new(file).relative_path_from(Pathname.new(@root_dir)) %>

--- a/pkg-info.yml
+++ b/pkg-info.yml
@@ -6,7 +6,7 @@ spec:
   require_path: lib
   has_rdoc: true
   extra_rdoc_files:
-  - README
+  - "README.md"
   - CHANGES
   - TODO
   - MIT-LICENSE
@@ -14,7 +14,8 @@ spec:
   bindir: bin
   executables:
   - t4rsh
-  - t4r-oauth-access
+  - "t4r-oauth-access"
+
   add_dependency:
     json: ">=1.6.5"
     oauth: ">=0.4.5"
@@ -25,7 +26,7 @@ spec:
   required_ruby_version: ">=1.8.7"
   author: Susan Potter
   email: twitter4r-users@googlegroups.com
-  homepage: http://twitter4r.rubyforge.org
+  homepage: "http://twitter4r.rubyforge.org"
   rubyforge_project: twitter4r
   files: <% (self.project_files + self.spec_files).each do |file| %>
   - <%= Pathname.new(file).relative_path_from(Pathname.new(@root_dir)) %>

--- a/pkg-info.yml
+++ b/pkg-info.yml
@@ -12,17 +12,17 @@ spec:
   - MIT-LICENSE
   autorequire: twitter
   bindir: bin
-  executables: 
+  executables:
   - t4rsh
   - t4r-oauth-access
   add_dependency:
-    json: >=1.1.1
-    oauth: >=0.4.1
+    json: ">=1.6.5"
+    oauth: ">=0.4.5"
   requirements:
   - Ruby 1.8.6+
   - json gem, version 0.4.3 or higher
   - jcode (for unicode support)
-  required_ruby_version: >=1.8.6
+  required_ruby_version: ">=1.8.7"
   author: Susan Potter
   email: twitter4r-users@googlegroups.com
   homepage: http://twitter4r.rubyforge.org

--- a/tasks/doc.rake
+++ b/tasks/doc.rake
@@ -5,8 +5,8 @@ Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'doc/rdoc'
   rdoc.title = "Twitter4R v#{Twitter::Version.to_version}: Idiomatic Ruby Open Source Library for the Twitter REST and Search APIs"
 #  rdoc.template = File.join(File.dirname(__FILE__), '..', 'config', 'rdoc_template.rb')
-  rdoc.options << '--line-numbers' << '--inline-source' << '--main' << 'README' << '--line-numbers'
-  rdoc.rdoc_files.include('README')
+  rdoc.options << '--line-numbers' << '--inline-source' << '--main' << 'README.md' << '--line-numbers'
+  rdoc.rdoc_files.include('README.md')
   rdoc.rdoc_files.include('CHANGES')
   rdoc.rdoc_files.include('MIT-LICENSE')
   rdoc.rdoc_files.include('lib/**/*.rb')

--- a/twitter4r.gemspec
+++ b/twitter4r.gemspec
@@ -1,0 +1,19 @@
+# Generated: Wed, 07 Mar 2012 16:13:09 -0000
+Gem::Specification.new do |s|
+  s.name = "twitter4r"
+  s.version = "0.7.1"
+  s.platform = Gem::Platform::RUBY
+  s.has_rdoc = true
+  s.extra_rdoc_files = ["README.md","CHANGES","TODO","MIT-LICENSE",]
+  s.summary = "A clean Twitter client API in pure Ruby. Will include Twitter add-ons also in Ruby."
+  s.author = "Susan Potter"
+  s.email = "twitter4r-users@googlegroups.com"
+  s.homepage = "http://twitter4r.rubyforge.org"
+  s.rubyforge_project = "twitter4r"
+  s.add_dependency("json", ">= 1.1.1")
+  s.add_dependency("oauth", ">= 0.4.1")
+#  s.require_path = "lib"
+  s.files = ["lib/twitter/client/account.rb","lib/twitter/client/auth.rb","lib/twitter/client/base.rb","lib/twitter/client/blocks.rb","lib/twitter/client/favorites.rb","lib/twitter/client/friendship.rb","lib/twitter/client/graph.rb","lib/twitter/client/messaging.rb","lib/twitter/client/profile.rb","lib/twitter/client/search.rb","lib/twitter/client/status.rb","lib/twitter/client/timeline.rb","lib/twitter/client/trends.rb","lib/twitter/client/user.rb","lib/twitter/client.rb","lib/twitter/config.rb","lib/twitter/console.rb","lib/twitter/core.rb","lib/twitter/ext/stdlib.rb","lib/twitter/ext.rb","lib/twitter/extras.rb","lib/twitter/meta.rb","lib/twitter/model.rb","lib/twitter/version.rb","lib/twitter.rb","spec/twitter/client/account_spec.rb","spec/twitter/client/auth_spec.rb","spec/twitter/client/base_spec.rb","spec/twitter/client/blocks_spec.rb","spec/twitter/client/favorites_spec.rb","spec/twitter/client/friendship_spec.rb","spec/twitter/client/graph_spec.rb","spec/twitter/client/messaging_spec.rb","spec/twitter/client/profile_spec.rb","spec/twitter/client/search_spec.rb","spec/twitter/client/status_spec.rb","spec/twitter/client/timeline_spec.rb","spec/twitter/client/trends_spec.rb","spec/twitter/client/user_spec.rb","spec/twitter/client_spec.rb","spec/twitter/config_spec.rb","spec/twitter/console_spec.rb","spec/twitter/core_spec.rb","spec/twitter/ext/stdlib_spec.rb","spec/twitter/extras_spec.rb","spec/twitter/meta_spec.rb","spec/twitter/model_spec.rb","spec/twitter/version_spec.rb",]
+  s.bindir = 'bin'
+  s.executables = ['t4rsh']
+end


### PR DESCRIPTION
I've added models for Urls, hashtags, mentions and media in tweets (read only as far as I know). 

I edited enough configuration to make the gem build properly for me (I think README needed referencing as README.md?)

Also committed the gemspec itself, as this allows the gem to be compiled straight from the git repository using bundler.
